### PR TITLE
Fix file id resolution on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,10 +76,12 @@ module.exports = function rollupPluginHypothetical(options) {
       return basicResolve(importee);
     },
     load: function(id) {
-      if(id in files) {
-        return files[id];
+      var normalizedId = unixStylePath(id);
+      
+      if(normalizedId in files) {
+        return files[normalizedId];
       } else if(!allowRealFiles) {
-        throw dneError(id);
+        throw dneError(normalizedId);
       }
     }
   };


### PR DESCRIPTION
Hey,

First of all thanks for this great plugin. :+1: 

On windows files are converted into Unix path style but when loading them they're not converted again.
This PR fixes that issue.

Thanks,
Barna
