### PR TITLE
Support to define external modules as hypothetical

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ To attach a sourcemap to a hypothetical file, simply pass in a `{ code, map }` o
 ### options.files
 An object whose keys are paths, either relative to the current working directory or absolute, and whose values are the code within the hypothetical files at those paths.
 
-### options.allowRealFiles
-Set this to `true` to allow mixing of hypothetical and actual files. "Actual" files can be files accessed by Rollup or produced by plugins further down the chain.
+### options.allowFallthrough
+Defaults to `false`. Set this to `true` to allow non-external imports to fall through. That way they can be handled either by Rollup's default behavior (reading from the filesystem) or by a plugin further down the chain if there is one.
 
-### options.allowExternalModules
-Set this to `false` to forbid importing of external modules.
+### options.allowExternalFallthrough
+Defaults to `true`. Set this to `false` to forbid external imports from falling through.
 
 ### options.leaveIdsAlone
 When this is set to `true`, the IDs in `import` statements won't be treated as paths and will instead be looked up directly in the `files` object. There will be no relative importing, path normalization, or restrictions on the contents of IDs.

--- a/README.md
+++ b/README.md
@@ -17,15 +17,17 @@ export default {
     files: {
       './dir/a.js': `
         import foo from './b.js';
-        import 'c';
         foo();
       `,
       './dir/b.js': `
+        import message from 'external';
         export default function foo() {
-          console.log("Hello, world!");
+          console.log(message);
         }
       `,
-      'c': 'console.log("This is an external module.");'
+      'external': `
+        export default "Hello, World!";
+      `
     }
   })]
 };

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ export default {
           console.log(message);
         }
       `,
-      'external': `
+      'external/': `
         export default "Hello, World!";
       `
     }
@@ -46,11 +46,27 @@ Defaults to `false`. Set this to `true` to allow non-external imports to fall th
 ### options.allowExternalFallthrough
 Defaults to `true`. Set this to `false` to forbid external imports from falling through.
 
+### options.allowRelativeExternalFallthrough
+Defaults to `false`. Set this to `true` to allow relative imports from supplied external modules to fall through. For instance, suppose you have the following `options.files`:
+
+```js
+{
+  'main.js': `
+    import 'external/x.js';
+  `,
+  'external/x.js': `
+    import './y.js';
+  `
+}
+```
+
+The supplied file `external/x.js` imports `external/y.js`, but `external/y.js` isn't supplied. This sort of thing is probably a mistake. If it isn't, set `options.allowRelativeExternalFallthrough` to `true` and **remember** to [include `external: ['external/y.js']` in the options you pass to `rollup.rollup`](https://rollupjs.org/#external-e-external-). If you forget that part, your build won't work, and weird things may happen instead!
+
 ### options.leaveIdsAlone
 When this is set to `true`, the IDs in `import` statements won't be treated as paths and will instead be looked up directly in the `files` object. There will be no relative importing, path normalization, or restrictions on the contents of IDs.
 
 ### options.impliedExtensions
-Set this to an array of file extensions to try appending to imports if an exact match isn't found. Defaults to `['.js']`. If this is set to `false` or an empty array, file extensions in imports will be treated as mandatory.
+Set this to an array of file extensions to try appending to imports if an exact match isn't found. Defaults to `['.js', '/']`. If this is set to `false` or an empty array, file extensions and trailing slashes in imports will be treated as mandatory.
 
 ### options.cwd
 When this is set to a directory name, relative file paths will be resolved relative to that directory rather than `process.cwd()`. When it's set to `false`, they will be resolved relative to an imaginary directory that cannot be expressed as an absolute path.

--- a/README.md
+++ b/README.md
@@ -17,13 +17,15 @@ export default {
     files: {
       './dir/a.js': `
         import foo from './b.js';
+        import 'c';
         foo();
       `,
       './dir/b.js': `
         export default function foo() {
           console.log("Hello, world!");
         }
-      `
+      `,
+      'c': 'console.log("This is an external module.");'
     }
   })]
 };

--- a/index.js
+++ b/index.js
@@ -46,8 +46,9 @@ module.exports = function rollupPluginHypothetical(options) {
     }
   } else {
     for(var f in files0) {
-      var p = path.normalize(unixStylePath(f));
-      if(!isAbsolute(p) && !isExternal(f)) {
+      var unixStyleF = unixStylePath(f);
+      var p = path.normalize(unixStyleF);
+      if(!isAbsolute(p) && !isExternal(unixStyleF)) {
         p = absolutify(p, cwd);
       }
       files[p] = files0[f];

--- a/test/test.js
+++ b/test/test.js
@@ -107,38 +107,47 @@ it("should forgo absolute paths when options.cwd is false", function() {
   }), "does not exist in the hypothetical file system");
 });
 
-it("should forbid external modules when options.allowExternalModules is false", function() {
+it("should forbid external fallthrough when options.allowExternalFallthrough is false", function() {
   return reject(rollup.rollup({
     entry: './x.js',
     plugins: [hypothetical({ files: {
       './x.js': 'import \'y.js\'; object.key = false;'
-    }, allowExternalModules: false })]
-  }), "xternal module");
+    }, allowExternalFallthrough: false })]
+  }), "does not exist in the hypothetical file system");
 });
 
-it("should allow importing of real files when options.allowRealFiles is true", function() {
+it("should allow fallthrough to real files when options.allowFallthrough is true", function() {
   return resolve(rollup.rollup({
     entry: './test/fixtures/x.js',
     plugins: [hypothetical({ files: {
       './test/fixtures/x.js': 'import \'./a.js\'; object.key2 = -3;'
-    }, allowRealFiles: true })]
+    }, allowFallthrough: true })]
   }), { key: true, key2: -3 });
 });
 
-it("should allow entry to be a real file when options.allowRealFiles is true", function() {
+it("should allow entry to fall through when options.allowFallthrough is true", function() {
   return resolve(rollup.rollup({
     entry: './test/fixtures/b.js',
     plugins: [hypothetical({ files: {
       './test/fixtures/a.js': 'object.key = false;'
-    }, allowRealFiles: true })]
+    }, allowFallthrough: true })]
   }), { key: false, key2: 0 });
 });
 
-it("should allow every file to be real when options.allowRealFiles is true", function() {
+it("should allow every file to fall through when options.allowFallthrough is true", function() {
   return resolve(rollup.rollup({
     entry: './test/fixtures/b.js',
-    plugins: [hypothetical({ allowRealFiles: true })]
+    plugins: [hypothetical({ allowFallthrough: true })]
   }), { key: true, key2: 0 });
+});
+
+it("shouldn't override options.allowExternalFallthrough when options.allowFallthrough is true", function() {
+  return reject(rollup.rollup({
+    entry: './x.js',
+    plugins: [hypothetical({ files: {
+      './x.js': 'import \'y.js\'; object.key = false;'
+    }, allowFallthrough: true, allowExternalFallthrough: false })]
+  }), "does not exist in the hypothetical file system");
 });
 
 it("should bypass this insufferable garbage when options.leaveIdsAlone is true", function() {

--- a/test/test.js
+++ b/test/test.js
@@ -221,21 +221,21 @@ describe("Paths", function() {
   it("should handle backslash-separated paths", function() {
     return resolve(rollup.rollup({
       entry: 'dir\\x.js',
-      plugins: [hypothetical({ files: { 'dir\\x.js': 'object.key = false;' } })]
+      plugins: [hypothetical({ files: { './dir\\x.js': 'object.key = false;' } })]
     }), { key: false });
   });
   
   it("should handle mixed slash style paths", function() {
     return resolve(rollup.rollup({
       entry: 'dir\\this-is-horrible/x.js',
-      plugins: [hypothetical({ files: { 'dir\\this-is-horrible/x.js': 'object.key = false;' } })]
+      plugins: [hypothetical({ files: { './dir\\this-is-horrible/x.js': 'object.key = false;' } })]
     }), { key: false });
   });
   
   it("should convert between slash styles", function() {
     return resolve(rollup.rollup({
       entry: 'dir\\x.js',
-      plugins: [hypothetical({ files: { 'dir/x.js': 'object.key = false;' } })]
+      plugins: [hypothetical({ files: { './dir/x.js': 'object.key = false;' } })]
     }), { key: false });
   });
   
@@ -270,7 +270,7 @@ describe("Paths", function() {
   it("should normalize module file paths", function() {
     return resolve(rollup.rollup({
       entry: './dir/../x.js',
-      plugins: [hypothetical({ files: { 'x.js': 'object.key = false;' } })]
+      plugins: [hypothetical({ files: { './x.js': 'object.key = false;' } })]
     }), { key: false });
   });
   
@@ -291,6 +291,16 @@ describe("Paths", function() {
         './x.lol': 'import \'./y\'; object.key = false;',
         './y.ha': 'object.key2 = 5;'
       }, impliedExtensions: ['.lol', '.ha'] })]
+    }), { key: false, key2: 5 });
+  });
+  
+  it("should handle external module", function() {
+    return resolve(rollup.rollup({
+      entry: 'x',
+      plugins: [hypothetical({ files: {
+        './x.js': 'import \'x\'; object.key = false;',
+        'x': 'object.key2 = 5;',
+      } })]
     }), { key: false, key2: 5 });
   });
   

--- a/test/test.js
+++ b/test/test.js
@@ -221,7 +221,7 @@ describe("Paths", function() {
   it("should handle backslash-separated paths", function() {
     return resolve(rollup.rollup({
       entry: 'dir\\x.js',
-      plugins: [hypothetical({ files: { './dir\\x.js': 'object.key = false;' } })]
+      plugins: [hypothetical({ files: { '.\\dir\\x.js': 'object.key = false;' } })]
     }), { key: false });
   });
   


### PR DESCRIPTION
I'm not sure if this is acceptable since it would be a breaking change.

```
hypothetical({
  files: {
    "foo/bar.js": ""
  }
})
```

The above setting is used to be treated as a relative file but this PR makes it an external module file.